### PR TITLE
Add intermediate upstreams to GCP and Azure services

### DIFF
--- a/aws/client/cloudwatch-logs.tf
+++ b/aws/client/cloudwatch-logs.tf
@@ -18,6 +18,14 @@ resource "aws_cloudwatch_log_group" "catalog_sidecars" {
   name_prefix = "${local.project_tag}-catalog-sidecars-"
 }
 
+resource "aws_cloudwatch_log_group" "customers" {
+  name_prefix = "${local.project_tag}-customers-"
+}
+
+resource "aws_cloudwatch_log_group" "customers_sidecars" {
+  name_prefix = "${local.project_tag}-customers-sidecars-"
+}
+
 resource "aws_cloudwatch_log_group" "mesh_gateway" {
   name_prefix = "${local.project_tag}-client-sidecars-"
 }
@@ -61,6 +69,22 @@ locals {
       awslogs-group         = aws_cloudwatch_log_group.catalog_sidecars.name
       awslogs-region        = var.aws_default_region
       awslogs-stream-prefix = "${local.project_tag}-catalog-sidecars-"
+    }
+  }
+  customers_logs_configuration = {
+    logDriver = "awslogs"
+    options = {
+      awslogs-group         = aws_cloudwatch_log_group.customers.name
+      awslogs-region        = var.aws_default_region
+      awslogs-stream-prefix = "${local.project_tag}-customers"
+    }
+  }
+  customers_sidecars_log_configuration = {
+    logDriver = "awslogs"
+    options = {
+      awslogs-group         = aws_cloudwatch_log_group.customers_sidecars.name
+      awslogs-region        = var.aws_default_region
+      awslogs-stream-prefix = "${local.project_tag}-customers-sidecars-"
     }
   }
   mesh_gateway_log_configuration = {

--- a/aws/client/cloudwatch-logs.tf
+++ b/aws/client/cloudwatch-logs.tf
@@ -87,6 +87,22 @@ locals {
       awslogs-stream-prefix = "${local.project_tag}-customers-sidecars-"
     }
   }
+  orders_logs_configuration = {
+    logDriver = "awslogs"
+    options = {
+      awslogs-group         = aws_cloudwatch_log_group.orders.name
+      awslogs-region        = var.aws_default_region
+      awslogs-stream-prefix = "${local.project_tag}-orders"
+    }
+  }
+  orders_sidecars_log_configuration = {
+    logDriver = "awslogs"
+    options = {
+      awslogs-group         = aws_cloudwatch_log_group.orders_sidecars.name
+      awslogs-region        = var.aws_default_region
+      awslogs-stream-prefix = "${local.project_tag}-orders-sidecars-"
+    }
+  }
   mesh_gateway_log_configuration = {
     logDriver = "awslogs"
     options = {

--- a/aws/client/cloudwatch-logs.tf
+++ b/aws/client/cloudwatch-logs.tf
@@ -26,6 +26,14 @@ resource "aws_cloudwatch_log_group" "customers_sidecars" {
   name_prefix = "${local.project_tag}-customers-sidecars-"
 }
 
+resource "aws_cloudwatch_log_group" "orders" {
+  name_prefix = "${local.project_tag}-orders-"
+}
+
+resource "aws_cloudwatch_log_group" "orders_sidecars" {
+  name_prefix = "${local.project_tag}-orders-sidecars-"
+}
+
 resource "aws_cloudwatch_log_group" "mesh_gateway" {
   name_prefix = "${local.project_tag}-client-sidecars-"
 }

--- a/aws/client/cloudwatch-logs.tf
+++ b/aws/client/cloudwatch-logs.tf
@@ -10,6 +10,14 @@ resource "aws_cloudwatch_log_group" "client_sidecars" {
   name_prefix = "${local.project_tag}-client-sidecars-"
 }
 
+resource "aws_cloudwatch_log_group" "catalog" {
+  name_prefix = "${local.project_tag}-catalog-"
+}
+
+resource "aws_cloudwatch_log_group" "catalog_sidecars" {
+  name_prefix = "${local.project_tag}-catalog-sidecars-"
+}
+
 resource "aws_cloudwatch_log_group" "mesh_gateway" {
   name_prefix = "${local.project_tag}-client-sidecars-"
 }
@@ -37,6 +45,22 @@ locals {
       awslogs-group         = aws_cloudwatch_log_group.client_sidecars.name
       awslogs-region        = var.aws_default_region
       awslogs-stream-prefix = "${local.project_tag}-client-sidecars-"
+    }
+  }
+  catalog_logs_configuration = {
+    logDriver = "awslogs"
+    options = {
+      awslogs-group         = aws_cloudwatch_log_group.catalog.name
+      awslogs-region        = var.aws_default_region
+      awslogs-stream-prefix = "${local.project_tag}-catalog"
+    }
+  }
+  catalog_sidecars_log_configuration = {
+    logDriver = "awslogs"
+    options = {
+      awslogs-group         = aws_cloudwatch_log_group.catalog_sidecars.name
+      awslogs-region        = var.aws_default_region
+      awslogs-stream-prefix = "${local.project_tag}-catalog-sidecars-"
     }
   }
   mesh_gateway_log_configuration = {

--- a/aws/client/ecs-lb.tf
+++ b/aws/client/ecs-lb.tf
@@ -23,9 +23,9 @@ resource "aws_lb_target_group" "client_alb_targets" {
     enabled = true
     path = "/"
     healthy_threshold = 3
-    unhealthy_threshold = 5
-    timeout = 30
-    interval = 60
+    unhealthy_threshold = 10
+    timeout = 60
+    interval = 120
     protocol = "HTTP"
   }
 

--- a/aws/client/ecs-services.tf
+++ b/aws/client/ecs-services.tf
@@ -87,3 +87,26 @@ resource "aws_ecs_service" "client" {
 
   propagate_tags = "TASK_DEFINITION"
 }
+
+# Upstream Facing Catalog Service
+resource "aws_ecs_service" "catalog" {
+  name = "catalog"
+  cluster = aws_ecs_cluster.main.arn
+  task_definition = module.catalog.task_definition_arn
+  desired_count = 1
+  launch_type = "FARGATE"
+
+  # this is only required if a service linked role for ECS isn't present in your account
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html
+  # iam_role = aws_iam_role.service_linked_ecs_role.arn
+
+  network_configuration {
+    subnets = aws_subnet.private.*.id
+    # defaults to the default VPC security group which allows all traffic from itself and all outbound traffic
+    # instead, we define our own for each ECS service!
+    security_groups = [aws_security_group.ecs_client_service.id, aws_security_group.consul_client.id]
+    assign_public_ip = false
+  }
+
+  propagate_tags = "TASK_DEFINITION"
+}

--- a/aws/client/ecs-services.tf
+++ b/aws/client/ecs-services.tf
@@ -110,3 +110,26 @@ resource "aws_ecs_service" "catalog" {
 
   propagate_tags = "TASK_DEFINITION"
 }
+
+# Upstream Facing Customers Service
+resource "aws_ecs_service" "customers" {
+  name = "customers"
+  cluster = aws_ecs_cluster.main.arn
+  task_definition = module.customers.task_definition_arn
+  desired_count = 1
+  launch_type = "FARGATE"
+
+  # this is only required if a service linked role for ECS isn't present in your account
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html
+  # iam_role = aws_iam_role.service_linked_ecs_role.arn
+
+  network_configuration {
+    subnets = aws_subnet.private.*.id
+    # defaults to the default VPC security group which allows all traffic from itself and all outbound traffic
+    # instead, we define our own for each ECS service!
+    security_groups = [aws_security_group.ecs_client_service.id, aws_security_group.consul_client.id]
+    assign_public_ip = false
+  }
+
+  propagate_tags = "TASK_DEFINITION"
+}

--- a/aws/client/ecs-services.tf
+++ b/aws/client/ecs-services.tf
@@ -133,3 +133,26 @@ resource "aws_ecs_service" "customers" {
 
   propagate_tags = "TASK_DEFINITION"
 }
+
+# Upstream Facing Orders Service
+resource "aws_ecs_service" "orders" {
+  name = "orders"
+  cluster = aws_ecs_cluster.main.arn
+  task_definition = module.orders.task_definition_arn
+  desired_count = 1
+  launch_type = "FARGATE"
+
+  # this is only required if a service linked role for ECS isn't present in your account
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html
+  # iam_role = aws_iam_role.service_linked_ecs_role.arn
+
+  network_configuration {
+    subnets = aws_subnet.private.*.id
+    # defaults to the default VPC security group which allows all traffic from itself and all outbound traffic
+    # instead, we define our own for each ECS service!
+    security_groups = [aws_security_group.ecs_client_service.id, aws_security_group.consul_client.id]
+    assign_public_ip = false
+  }
+
+  propagate_tags = "TASK_DEFINITION"
+}

--- a/aws/client/ecs-task-definitions.tf
+++ b/aws/client/ecs-task-definitions.tf
@@ -38,7 +38,7 @@ module "client" {
         },
         {
           name = "UPSTREAM_URIS" # Fake service upstream service to call to
-          value = "http://localhost:1234,http://localhost:1235,http://localhost:1236" # point all upstreams to the proxy
+          value = "http://localhost:1234,http://localhost:1235,http://localhost:1236,http://localhost:1237" # point all upstreams to the proxy
         }
       ]
     }
@@ -53,17 +53,17 @@ module "client" {
         }
     },
     {
-      destinationName = "catalog"
+      destinationName = "orders"
       localBindPort = 1235
     },
     {
-      destinationName = "customers"
+      destinationName = "catalog"
       localBindPort = 1236
     },
     {
-      destinationName = "orders"
+      destinationName = "customers"
       localBindPort = 1237
-    }
+    },
   ]
 
   # All settings required by the mesh-task module

--- a/aws/client/ecs-task-definitions.tf
+++ b/aws/client/ecs-task-definitions.tf
@@ -38,7 +38,7 @@ module "client" {
         },
         {
           name = "UPSTREAM_URIS" # Fake service upstream service to call to
-          value = "http://localhost:1234,http://localhost:1235,http://localhost:1236" # point all upstreams to the proxy
+          value = "http://localhost:1234,http://localhost:1235,http://localhost:1236,http://localhost:1237" # point all upstreams to the proxy
         }
       ]
     }
@@ -62,6 +62,10 @@ module "client" {
     {
       destinationName = "catalog"
       localBindPort = 1236
+    },
+    {
+      destinationName = "customers"
+      localBindPort = 1237
     }
   ]
 
@@ -180,6 +184,106 @@ module "catalog" {
   gossip_key_secret_arn = aws_secretsmanager_secret.consul_gossip_key.arn
 
   log_configuration = local.catalog_sidecars_log_configuration
+  
+  # https://github.com/hashicorp/consul-ecs/blob/main/config/schema.json#L74#
+  # to tell the proxy and consul-ecs how to contact the service
+  port = "9090" 
+  tls = true
+
+  # DNS to join consul on
+  retry_join = jsondecode(base64decode(data.hcp_consul_cluster.aws.consul_config_file))["retry_join"]
+
+  # Admin Partitions
+  consul_partition = "default"
+  consul_namespace = "default" # hopefully puts it in the client partition's default namespace
+  consul_image = "public.ecr.aws/hashicorp/consul-enterprise:1.15.2-ent"
+
+  # not 100 if this is required, but it's present in the other ecs tasks and services
+  additional_task_role_policies = [aws_iam_policy.execute_command.arn]
+
+  depends_on = [
+    module.consul_acl_controller
+  ]
+}
+
+module "customers" {
+  source            = "hashicorp/consul-ecs/aws//modules/mesh-task"
+  version           = "0.6.0"
+
+  family = "customers"
+
+  # required for Fargate launch type
+  requires_compatibilities = ["FARGATE"]
+  cpu = 256
+  memory = 512
+
+  container_definitions = [
+    {
+      name = "client"
+      image = "ghcr.io/nicholasjackson/fake-service:v0.25.2"
+      cpu = 0 # take up proportional cpu
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = 9090
+          hostPort = 9090 # though, access to the ephemeral port range is needed to connect on EC2, the exact port is required on Fargate from a security group standpoint.
+          protocol = "tcp"
+        }
+      ]
+
+      logConfiguration = local.customers_logs_configuration
+
+      # Fake Service settings are set via Environment variables
+      environment = [
+        {
+          name = "NAME" # Fake Service name
+          value = "customers" 
+        },
+        {
+          name = "MESSAGE" # Fake Service message to return
+          value = "Hello from the customers service!"
+        },
+        {
+          name = "UPSTREAM_URIS" # Fake service upstream service to call to
+          value = "http://localhost:1234,http://localhost:1235" # point all upstreams to the proxy
+        }
+      ]
+    }
+  ]
+
+  upstreams = [
+    {
+      destinationName = "tea-customers"
+      localBindPort = 1234
+        meshGateway = {
+          mode = "local"
+        }
+    },
+    {
+      destinationName = "coffee-customers"
+      localBindPort = 1235
+        meshGateway = {
+          mode = "local"
+        }
+    }
+  ]
+
+  # All settings required by the mesh-task module
+  acls = true
+  # enable_acl_token_replication = true
+  consul_http_addr             = "${data.hcp_consul_cluster.aws.consul_private_endpoint_url}"
+
+  consul_datacenter = data.hcp_consul_cluster.aws.datacenter
+  consul_primary_datacenter = data.hcp_consul_cluster.aws.datacenter # required for mesh gateways?
+
+  # really not sure how this is different from consul_server_ca_cert_arn...
+  # consul_https_ca_cert_arn = aws_secretsmanager_secret.consul_root_ca_cert.arn # apparently not required on HCP
+  consul_server_ca_cert_arn = aws_secretsmanager_secret.consul_root_ca_cert.arn
+
+  gossip_key_secret_arn = aws_secretsmanager_secret.consul_gossip_key.arn
+
+  log_configuration = local.customers_sidecars_log_configuration
   
   # https://github.com/hashicorp/consul-ecs/blob/main/config/schema.json#L74#
   # to tell the proxy and consul-ecs how to contact the service

--- a/aws/client/ecs-task-definitions.tf
+++ b/aws/client/ecs-task-definitions.tf
@@ -119,7 +119,7 @@ module "catalog" {
 
   container_definitions = [
     {
-      name = "client"
+      name = "catalog"
       image = "ghcr.io/nicholasjackson/fake-service:v0.25.2"
       cpu = 0 # take up proportional cpu
       essential = true
@@ -219,7 +219,7 @@ module "customers" {
 
   container_definitions = [
     {
-      name = "client"
+      name = "customers"
       image = "ghcr.io/nicholasjackson/fake-service:v0.25.2"
       cpu = 0 # take up proportional cpu
       essential = true

--- a/aws/client/ecs-task-definitions.tf
+++ b/aws/client/ecs-task-definitions.tf
@@ -38,7 +38,7 @@ module "client" {
         },
         {
           name = "UPSTREAM_URIS" # Fake service upstream service to call to
-          value = "http://localhost:1234,http://localhost:1235" # point all upstreams to the proxy
+          value = "http://localhost:1234,http://localhost:1235,http://localhost:1236" # point all upstreams to the proxy
         }
       ]
     }
@@ -58,6 +58,10 @@ module "client" {
         meshGateway = {
           mode = "local"
         }
+    },
+    {
+      destinationName = "catalog"
+      localBindPort = 1236
     }
   ]
 

--- a/aws/client/ecs-task-definitions.tf
+++ b/aws/client/ecs-task-definitions.tf
@@ -97,3 +97,103 @@ module "client" {
     module.consul_acl_controller
   ]
 }
+
+module "catalog" {
+  source            = "hashicorp/consul-ecs/aws//modules/mesh-task"
+  version           = "0.6.0"
+
+  family = "catalog"
+
+  # required for Fargate launch type
+  requires_compatibilities = ["FARGATE"]
+  cpu = 256
+  memory = 512
+
+  container_definitions = [
+    {
+      name = "client"
+      image = "ghcr.io/nicholasjackson/fake-service:v0.25.2"
+      cpu = 0 # take up proportional cpu
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = 9090
+          hostPort = 9090 # though, access to the ephemeral port range is needed to connect on EC2, the exact port is required on Fargate from a security group standpoint.
+          protocol = "tcp"
+        }
+      ]
+
+      logConfiguration = local.catalog_logs_configuration
+
+      # Fake Service settings are set via Environment variables
+      environment = [
+        {
+          name = "NAME" # Fake Service name
+          value = "catalog" 
+        },
+        {
+          name = "MESSAGE" # Fake Service message to return
+          value = "Hello from the catalog service!"
+        },
+        {
+          name = "UPSTREAM_URIS" # Fake service upstream service to call to
+          value = "http://localhost:1234,http://localhost:1235" # point all upstreams to the proxy
+        }
+      ]
+    }
+  ]
+
+  upstreams = [
+    {
+      destinationName = "tea-catalog"
+      localBindPort = 1234
+        meshGateway = {
+          mode = "local"
+        }
+    },
+    {
+      destinationName = "coffee-catalog"
+      localBindPort = 1235
+        meshGateway = {
+          mode = "local"
+        }
+    }
+  ]
+
+  # All settings required by the mesh-task module
+  acls = true
+  # enable_acl_token_replication = true
+  consul_http_addr             = "${data.hcp_consul_cluster.aws.consul_private_endpoint_url}"
+
+  consul_datacenter = data.hcp_consul_cluster.aws.datacenter
+  consul_primary_datacenter = data.hcp_consul_cluster.aws.datacenter # required for mesh gateways?
+
+  # really not sure how this is different from consul_server_ca_cert_arn...
+  # consul_https_ca_cert_arn = aws_secretsmanager_secret.consul_root_ca_cert.arn # apparently not required on HCP
+  consul_server_ca_cert_arn = aws_secretsmanager_secret.consul_root_ca_cert.arn
+
+  gossip_key_secret_arn = aws_secretsmanager_secret.consul_gossip_key.arn
+
+  log_configuration = local.catalog_sidecars_log_configuration
+  
+  # https://github.com/hashicorp/consul-ecs/blob/main/config/schema.json#L74#
+  # to tell the proxy and consul-ecs how to contact the service
+  port = "9090" 
+  tls = true
+
+  # DNS to join consul on
+  retry_join = jsondecode(base64decode(data.hcp_consul_cluster.aws.consul_config_file))["retry_join"]
+
+  # Admin Partitions
+  consul_partition = "default"
+  consul_namespace = "default" # hopefully puts it in the client partition's default namespace
+  consul_image = "public.ecr.aws/hashicorp/consul-enterprise:1.15.2-ent"
+
+  # not 100 if this is required, but it's present in the other ecs tasks and services
+  additional_task_role_policies = [aws_iam_policy.execute_command.arn]
+
+  depends_on = [
+    module.consul_acl_controller
+  ]
+}

--- a/aws/client/ecs-task-definitions.tf
+++ b/aws/client/ecs-task-definitions.tf
@@ -38,7 +38,7 @@ module "client" {
         },
         {
           name = "UPSTREAM_URIS" # Fake service upstream service to call to
-          value = "http://localhost:1234,http://localhost:1235,http://localhost:1236,http://localhost:1237" # point all upstreams to the proxy
+          value = "http://localhost:1234,http://localhost:1235,http://localhost:1236" # point all upstreams to the proxy
         }
       ]
     }
@@ -46,25 +46,22 @@ module "client" {
 
   upstreams = [
     {
-      destinationName = "shipping-azure"
+      destinationName = "loyalty-gcp"
       localBindPort = 1234
         meshGateway = {
           mode = "local"
         }
     },
     {
-      destinationName = "loyalty-gcp"
-      localBindPort = 1235
-        meshGateway = {
-          mode = "local"
-        }
-    },
-    {
       destinationName = "catalog"
-      localBindPort = 1236
+      localBindPort = 1235
     },
     {
       destinationName = "customers"
+      localBindPort = 1236
+    },
+    {
+      destinationName = "orders"
       localBindPort = 1237
     }
   ]
@@ -284,6 +281,99 @@ module "customers" {
   gossip_key_secret_arn = aws_secretsmanager_secret.consul_gossip_key.arn
 
   log_configuration = local.customers_sidecars_log_configuration
+  
+  # https://github.com/hashicorp/consul-ecs/blob/main/config/schema.json#L74#
+  # to tell the proxy and consul-ecs how to contact the service
+  port = "9090" 
+  tls = true
+
+  # DNS to join consul on
+  retry_join = jsondecode(base64decode(data.hcp_consul_cluster.aws.consul_config_file))["retry_join"]
+
+  # Admin Partitions
+  consul_partition = "default"
+  consul_namespace = "default" # hopefully puts it in the client partition's default namespace
+  consul_image = "public.ecr.aws/hashicorp/consul-enterprise:1.15.2-ent"
+
+  # not 100 if this is required, but it's present in the other ecs tasks and services
+  additional_task_role_policies = [aws_iam_policy.execute_command.arn]
+
+  depends_on = [
+    module.consul_acl_controller
+  ]
+}
+
+module "orders" {
+  source            = "hashicorp/consul-ecs/aws//modules/mesh-task"
+  version           = "0.6.0"
+
+  family = "orders"
+
+  # required for Fargate launch type
+  requires_compatibilities = ["FARGATE"]
+  cpu = 256
+  memory = 512
+
+  container_definitions = [
+    {
+      name = "orders"
+      image = "ghcr.io/nicholasjackson/fake-service:v0.25.2"
+      cpu = 0 # take up proportional cpu
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = 9090
+          hostPort = 9090 # though, access to the ephemeral port range is needed to connect on EC2, the exact port is required on Fargate from a security group standpoint.
+          protocol = "tcp"
+        }
+      ]
+
+      logConfiguration = local.orders_logs_configuration
+
+      # Fake Service settings are set via Environment variables
+      environment = [
+        {
+          name = "NAME" # Fake Service name
+          value = "orders" 
+        },
+        {
+          name = "MESSAGE" # Fake Service message to return
+          value = "Hello from the orders service!"
+        },
+        {
+          name = "UPSTREAM_URIS" # Fake service upstream service to call to
+          value = "http://localhost:1234" # point all upstreams to the proxy
+        }
+      ]
+    }
+  ]
+
+  upstreams = [
+    {
+      destinationName = "shipping-azure"
+      localBindPort = 1234
+        meshGateway = {
+          mode = "local"
+        }
+    },
+  ]
+
+  # All settings required by the mesh-task module
+  acls = true
+  # enable_acl_token_replication = true
+  consul_http_addr             = "${data.hcp_consul_cluster.aws.consul_private_endpoint_url}"
+
+  consul_datacenter = data.hcp_consul_cluster.aws.datacenter
+  consul_primary_datacenter = data.hcp_consul_cluster.aws.datacenter # required for mesh gateways?
+
+  # really not sure how this is different from consul_server_ca_cert_arn...
+  # consul_https_ca_cert_arn = aws_secretsmanager_secret.consul_root_ca_cert.arn # apparently not required on HCP
+  consul_server_ca_cert_arn = aws_secretsmanager_secret.consul_root_ca_cert.arn
+
+  gossip_key_secret_arn = aws_secretsmanager_secret.consul_gossip_key.arn
+
+  log_configuration = local.orders_sidecars_log_configuration
   
   # https://github.com/hashicorp/consul-ecs/blob/main/config/schema.json#L74#
   # to tell the proxy and consul-ecs how to contact the service

--- a/aws/consul/consul-config.tf
+++ b/aws/consul/consul-config.tf
@@ -100,3 +100,15 @@ resource "consul_config_entry" "client_to_customers" {
     }]
   })
 }
+
+resource "consul_config_entry" "client_to_orders" {
+  kind = "service-intentions"
+  name = "orders"
+
+  config_json = jsonencode({
+    Sources = [{
+      Name = "client"
+      Action = "allow"
+    }]
+  })
+}

--- a/aws/consul/consul-config.tf
+++ b/aws/consul/consul-config.tf
@@ -27,7 +27,9 @@ resource "consul_config_entry" "client_to_catalog" {
   name = "catalog"
 
   config_json = jsonencode({
-    Name = "client"
-    Action = "allow"
+    Sources = [{
+      Name = "client"
+      Action = "allow"
+    }]
   })
 }

--- a/aws/consul/consul-config.tf
+++ b/aws/consul/consul-config.tf
@@ -23,7 +23,7 @@ resource "consul_config_entry" "loyalty" {
 }
 
 resource "consul_config_entry" "client_to_catalog" {
-  kind = "service-intention"
+  kind = "service-intentions"
   name = "catalog"
 
   config_json = jsonencode({

--- a/aws/consul/consul-config.tf
+++ b/aws/consul/consul-config.tf
@@ -25,6 +25,18 @@ resource "consul_config_entry" "tea_catalog" {
   })
 }
 
+resource "consul_config_entry" "tea_customers" {
+  kind = "service-resolver"
+  name = "tea-customers"
+
+  config_json = jsonencode({
+    Redirect = {
+      Service = "tea-customers"
+      Peer = "azure-default"
+    }
+  })
+}
+
 
 # GCP Service Resolvers
 resource "consul_config_entry" "loyalty" {
@@ -51,9 +63,35 @@ resource "consul_config_entry" "coffee_catalog" {
   })
 }
 
+resource "consul_config_entry" "coffee_customers" {
+  kind = "service-resolver"
+  name = "coffee-customers"
+
+  config_json = jsonencode({
+    Redirect = {
+      Service = "coffee-customers"
+      Peer = "gcp-default"
+    }
+  })
+}
+
+
+# AWS Local Intentions
 resource "consul_config_entry" "client_to_catalog" {
   kind = "service-intentions"
   name = "catalog"
+
+  config_json = jsonencode({
+    Sources = [{
+      Name = "client"
+      Action = "allow"
+    }]
+  })
+}
+
+resource "consul_config_entry" "client_to_customers" {
+  kind = "service-intentions"
+  name = "customers"
 
   config_json = jsonencode({
     Sources = [{

--- a/aws/consul/consul-config.tf
+++ b/aws/consul/consul-config.tf
@@ -21,3 +21,13 @@ resource "consul_config_entry" "loyalty" {
     }
   })
 }
+
+resource "consul_config_entry" "client_to_catalog" {
+  kind = "service-intention"
+  name = "catalog"
+
+  config_json = jsonencode({
+    Name = "client"
+    Action = "allow"
+  })
+}

--- a/aws/consul/consul-config.tf
+++ b/aws/consul/consul-config.tf
@@ -22,6 +22,18 @@ resource "consul_config_entry" "loyalty" {
   })
 }
 
+resource "consul_config_entry" "coffee_catalog" {
+  kind = "service-resolver"
+  name = "coffee-catalog"
+
+  config_json = jsonencode({
+    Redirect = {
+      Service = "coffee-catalog"
+      Peer = "gcp-default"
+    }
+  })
+}
+
 resource "consul_config_entry" "client_to_catalog" {
   kind = "service-intentions"
   name = "catalog"

--- a/aws/consul/consul-config.tf
+++ b/aws/consul/consul-config.tf
@@ -1,3 +1,6 @@
+# Note, the service-resolvers exist to bypass the fact that consul-ecs doesn't support a destinationPeer option
+
+# Azure Service Resolvers
 resource "consul_config_entry" "shipping_azure" {
   kind = "service-resolver"
   name = "shipping-azure"
@@ -10,6 +13,20 @@ resource "consul_config_entry" "shipping_azure" {
   })
 }
 
+resource "consul_config_entry" "tea_catalog" {
+  kind = "service-resolver"
+  name = "tea-catalog"
+
+  config_json = jsonencode({
+    Redirect = {
+      Service = "tea-catalog"
+      Peer = "azure-default"
+    }
+  })
+}
+
+
+# GCP Service Resolvers
 resource "consul_config_entry" "loyalty" {
   kind = "service-resolver"
   name = "loyalty-gcp"

--- a/azure/config.tf
+++ b/azure/config.tf
@@ -52,3 +52,16 @@ resource "consul_config_entry" "shipping_intention" {
     }]
   })
 }
+
+resource "consul_config_entry" "tea_catalog_intention" {
+  name = "tea-catalog"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [{
+      Name = "catalog"
+      Peer = "aws-default"
+      Action = "allow"
+    }]
+  })
+}

--- a/azure/config.tf
+++ b/azure/config.tf
@@ -65,3 +65,16 @@ resource "consul_config_entry" "tea_catalog_intention" {
     }]
   })
 }
+
+resource "consul_config_entry" "tea_customers_intention" {
+  name = "tea-customers"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [{
+      Name = "customers"
+      Peer = "aws-default"
+      Action = "allow"
+    }]
+  })
+}

--- a/azure/config.tf
+++ b/azure/config.tf
@@ -46,7 +46,7 @@ resource "consul_config_entry" "shipping_intention" {
 
   config_json = jsonencode({
     Sources = [{
-    Name = "client"
+    Name = "orders"
     Peer = "aws-default"
     Action = "allow"
     }]

--- a/gcp/consul/intentions.tf
+++ b/gcp/consul/intentions.tf
@@ -31,3 +31,20 @@ resource "consul_config_entry" "service_intentions_coffee_catalog" {
     ]
   })
 }
+
+resource "consul_config_entry" "service_intentions_coffee_customers" {
+  name = "coffee-customers"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "customers"
+        Peer       = "aws-default"
+        Precedence = 9
+        Type       = "consul"
+      }
+    ]
+  })
+}

--- a/gcp/consul/intentions.tf
+++ b/gcp/consul/intentions.tf
@@ -14,3 +14,20 @@ resource "consul_config_entry" "service_intentions_loyalty" {
     ]
   })
 }
+
+resource "consul_config_entry" "service_intentions_coffee_catalog" {
+  name = "coffee-catalog"
+  kind = "service-intentions"
+
+  config_json = jsonencode({
+    Sources = [
+      {
+        Action     = "allow"
+        Name       = "catalog"
+        Peer       = "aws-default"
+        Precedence = 9
+        Type       = "consul"
+      }
+    ]
+  })
+}

--- a/gcp/services/catalog.tf
+++ b/gcp/services/catalog.tf
@@ -68,7 +68,7 @@ resource "kubernetes_manifest" "deployment_catalog" {
                 },
                 {
                   "name"  = "NAME"
-                  "value" = "coffee-catalog"
+                  "value" = "coffee-catalog-GCP"
                 },
                 {
                   "name"  = "MESSAGE"

--- a/gcp/services/customers.tf
+++ b/gcp/services/customers.tf
@@ -68,7 +68,7 @@ resource "kubernetes_manifest" "deployment_customers" {
                 },
                 {
                   "name"  = "NAME"
-                  "value" = "coffee-customers"
+                  "value" = "coffee-customers-GCP"
                 },
                 {
                   "name"  = "MESSAGE"


### PR DESCRIPTION
This gets services into the structure from rosemary's diagram.  For now all AWS services are in the same ECS cluster until we get the admin partition thing figured out.